### PR TITLE
Added the option to pass a string to values[:divider] which would be use...

### DIFF
--- a/lib/microformats_helper/helpers.rb
+++ b/lib/microformats_helper/helpers.rb
@@ -42,6 +42,9 @@ module MicroformatsHelper
       # support for additional HTML options, e.g. id
       html_options = (values[:html] || {})
 
+      # support for more regional divider styles to seperate "locality" and "region" fields
+      values[:divider] ||= " - "
+
       # support for additional classes
       if classes = values[:class]
         classes << " vcard"
@@ -91,7 +94,7 @@ module MicroformatsHelper
       end
       if region = values[:region]
         address = true
-        adr += " - " + content_tag("span", region, {:class => "region"}, escape)
+        adr += values[:divider] + content_tag("span", region, {:class => "region"}, escape)
       end
       if postal_code = values[:postal_code]
         address = true

--- a/test/microformats_helper_test.rb
+++ b/test/microformats_helper_test.rb
@@ -44,6 +44,11 @@ class MicroformatsHelperTest < ActionController::TestCase
     output = hcard(:fn => "John Doe", :street => "123 Fictional Lane", :locality => "Neverland", :region => "Imagination")
     assert_equal "<span class=\"vcard\">\n<span class=\"fn n\">John Doe</span>\n\n<span class=\"adr\"><span class=\"street-address\">123 Fictional Lane</span> <span class=\"locality\">Neverland</span> - <span class=\"region\">Imagination</span></span>\n</span>", output
   end
+
+  def test_hcard_address_with_divider_value
+    output = hcard(:fn => "John Doe", :street => "123 Fictional Lane", :locality => "Neverland", :region => "Imagination", :divider => ", ")
+    assert_equal "<span class=\"vcard\">\n<span class=\"fn n\">John Doe</span>\n\n<span class=\"adr\"><span class=\"street-address\">123 Fictional Lane</span> <span class=\"locality\">Neverland</span>, <span class=\"region\">Imagination</span></span>\n</span>", output
+  end
   
   def test_hcard_email
     output = hcard(:fn => "John Doe", :email => "john@doe.org")


### PR DESCRIPTION
...d instead of the hyphen to separate locality and region.
